### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master # Here source code branch is `master`, it could be other branch
 
+permissions:
+  contents: write
+
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/marcocrowe/marcocrowe.github.io/security/code-scanning/1](https://github.com/marcocrowe/marcocrowe.github.io/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/build-jekyll.yml` at the workflow root (recommended here since there is one job).  
Because this workflow deploys to `gh-pages`, it needs at least:

- `contents: write` (to push deployment content)
- (optionally) keep other scopes absent, which means `none` by default

This is the minimal practical least-privilege fix that preserves existing behavior (successful deployment) while removing reliance on repository/org defaults.

Change location:
- File: `.github/workflows/build-jekyll.yml`
- Insert `permissions:` between the `on:` block and `jobs:` block.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
