### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,9 @@
 
 name: "Jekyll CI"
 
+permissions:
+  contents: read
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch


### PR DESCRIPTION
Potential fix for [https://github.com/marcocrowe/marcocrowe.github.io/security/code-scanning/2](https://github.com/marcocrowe/marcocrowe.github.io/security/code-scanning/2)

Add an explicit workflow-level `permissions` block so all jobs inherit least-privilege token access.  
Best fix here: in `.github/workflows/codeql-analysis.yml`, insert at the top level (after `name` is a clear location) the following:

```yml
permissions:
  contents: read
```

Why this is best:
- It addresses CodeQL directly.
- It preserves existing functionality (`checkout` needs `contents: read`).
- It avoids over-granting and documents intended access.
- One centralized change covers both jobs.

No imports/methods/dependencies are needed for YAML workflow changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
